### PR TITLE
Locks the Capistrano version to a minor release (rather than a patch release)

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid for current version and patch releases of Capistrano
-lock "~> 3.11.2"
+lock "~> 3.11"
 
 set :application, "plantain"
 set :repo_url, "https://github.com/pulibrary/plantain.git"


### PR DESCRIPTION
Please see https://github.com/capistrano/capistrano/issues/1930 for reference.