### PR TITLE
Providing steps within the README for retrieving the PULFA EAD Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,40 @@ following:
 ```
 
 ##### Retrieving the Documents from SVN
-In order to download the EAD documents from Princeton University Library
-servers, one will need to please request both the server name, as well as the
-credentials for retrieving the documents from ITIMS staff. Once these have been
-obtained, one must still ensure that one has SVN installed locally:
+
+_Installing Subversion (SVN)_
+One must ensure that SVN is installed locally:
 
 *In a macOS Environment:*
 ```
 brew install svn
 ```
 
-Then, please download the files with the following:
+###### Using `lpass`
+
+_Installing `lpass` for authentication [LastPass](https://lastpass.com)_
+
+*In a macOS Environment:*
+```
+brew install lpass
+```
+
+_Authenticating on LastPass_
+```
+lpass login username@domain.edu
+```
+
+_Downloading the files over SVN_
+```
+bundle exec rake pulfa:checkout
+```
+
+###### Manually Retrieving the Documents (without `lpass`)
+In order to download the EAD documents from Princeton University Library
+servers, one will need to please retrieve the server name, as well as the
+credentials for retrieving the documents from LastPass. Then, please download
+the files with the following:
+
 ```
 export PULFA_SERVER_URL=[the PULFA subversion URL]
 export PULFA_USERNAME=[the PULFA subversion username]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ following:
 
 ##### Retrieving the Documents from SVN
 
-_Installing Subversion (SVN)_
 One must ensure that SVN is installed locally:
 
 *In a macOS Environment:*
@@ -64,22 +63,16 @@ One must ensure that SVN is installed locally:
 brew install svn
 ```
 
-###### Using `lpass`
-
-_Installing `lpass` for authentication [LastPass](https://lastpass.com)_
+###### Using `lpass` for authentication [LastPass](https://lastpass.com)
 
 *In a macOS Environment:*
 ```
 brew install lpass
 ```
 
-_Authenticating on LastPass_
+Then please invoke the following:
 ```
 lpass login username@domain.edu
-```
-
-_Downloading the files over SVN_
-```
 bundle exec rake pulfa:checkout
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,24 @@ following:
 [...] mudd
 [...] rarebooks
 ```
+
+##### Retrieving the Documents from SVN
+In order to download the EAD documents from Princeton University Library
+servers, one will need to please request both the server name, as well as the
+credentials for retrieving the documents from ITIMS staff. Once these have been
+obtained, one must still ensure that one has SVN installed locally:
+
+*In a macOS Environment:*
+```
+brew install svn
+```
+
+Then, please download the files with the following:
+```
+export PULFA_SERVER_URL=[the PULFA subversion URL]
+export PULFA_USERNAME=[the PULFA subversion username]
+svn checkout $PULFA_SERVER_URL --username $PULFA_USERNAME eads/pulfa/
+```
+
+One should now have access to the EAD files from within the local development 
+environment.

--- a/lib/plantain/normalized_date.rb
+++ b/lib/plantain/normalized_date.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Plantain
+  # Class for normalizing dates from year strings extracted from the EAD
+  class NormalizedDate < Arclight::NormalizedDate
+    # Constructor
+    # @param inclusive [Array<String>, String]
+    # @param bulk [Array<String>, String]
+    # @param other [Array<String>, String]
+    def initialize(inclusive, bulk = nil, other = nil)
+      if inclusive.is_a? Array # of YYYY-YYYY for ranges
+        @inclusive = YearRange.new(inclusive.include?("/") ? inclusive : inclusive.map { |v| v.tr("-", "/") }).to_s
+      elsif inclusive.present?
+        @inclusive = inclusive.strip
+      end
+      bulk_date = Array.wrap(bulk).first
+      @bulk = bulk_date.strip if bulk_date.present?
+      other_date = Array.wrap(other).first
+      @other = other_date.strip if other_date.present?
+    end
+  end
+end

--- a/lib/plantain/normalized_title.rb
+++ b/lib/plantain/normalized_title.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Plantain
+  # Class for normalizing document titles from a set of title and date values extracted from the EAD Document
+  class NormalizedTitle < Arclight::NormalizedTitle
+    private
+
+      # Generates the normalized title
+      # @return [String]
+      def normalize
+        result = [title, date].compact.join(", ")
+        result = title if result.blank?
+        result
+      end
+  end
+end

--- a/lib/plantain/traject/ead2_config.rb
+++ b/lib/plantain/traject/ead2_config.rb
@@ -1,0 +1,512 @@
+# frozen_string_literal: true
+
+require "logger"
+require "traject"
+require "traject/nokogiri_reader"
+require "traject_plus"
+require "traject_plus/macros"
+require "arclight/level_label"
+require "arclight/normalized_date"
+require "arclight/normalized_title"
+require "active_model/conversion" ## Needed for Arclight::Repository
+require "active_support/core_ext/array/wrap"
+require "arclight/digital_object"
+require "arclight/year_range"
+require "arclight/repository"
+require "arclight/missing_id_strategy"
+require "arclight/traject/nokogiri_namespaceless_reader"
+require_relative "../normalized_title"
+require_relative "../normalized_date"
+require_relative "../year_range"
+extend TrajectPlus::Macros
+# rubocop:enable Style/MixinUsage
+
+NAME_ELEMENTS = %w[corpname famname name persname].freeze
+
+SEARCHABLE_NOTES_FIELDS = %w[
+  accessrestrict
+  accruals
+  altformavail
+  appraisal
+  arrangement
+  bibliography
+  bioghist
+  custodhist
+  fileplan
+  note
+  odd
+  originalsloc
+  otherfindaid
+  phystech
+  prefercite
+  processinfo
+  relatedmaterial
+  scopecontent
+  separatedmaterial
+  userestrict
+].freeze
+
+DID_SEARCHABLE_NOTES_FIELDS = %w[
+  abstract
+  materialspec
+  physloc
+].freeze
+
+settings do
+  provide "reader_class_name", "Arclight::Traject::NokogiriNamespacelessReader"
+  provide "solr_writer.commit_on_close", "true"
+  provide "repository", ENV["REPOSITORY_ID"]
+  provide "logger", Logger.new($stderr)
+end
+
+each_record do |_record, context|
+  next unless settings["repository"]
+
+  context.clipboard[:repository] = Arclight::Repository.find_by(
+    slug: settings["repository"]
+  ).name
+end
+
+# ==================
+# Top level document
+# ==================
+
+to_field "id", extract_xpath("/ead/eadheader/eadid"), strip, tr(".", "-")
+to_field "title_filing_si", extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')
+to_field "title_ssm", extract_xpath("/ead/archdesc/did/unittitle")
+to_field "title_teim", extract_xpath("/ead/archdesc/did/unittitle")
+to_field "ead_ssi", extract_xpath("/ead/eadheader/eadid")
+
+to_field "unitdate_ssm", extract_xpath("/ead/archdesc/did/unitdate")
+to_field "unitdate_bulk_ssim", extract_xpath('/ead/archdesc/did/unitdate[@type="bulk"]')
+to_field "unitdate_inclusive_ssm", extract_xpath('/ead/archdesc/did/unitdate[@type="inclusive"]')
+to_field "unitdate_other_ssim", extract_xpath("/ead/archdesc/did/unitdate[not(@type)]")
+
+# All top-level docs treated as 'collection' for routing / display purposes
+to_field "level_ssm" do |_record, accumulator|
+  accumulator << "collection"
+end
+
+# Keep the original top-level archdesc/@level for Level facet in addition to 'Collection'
+to_field "level_sim" do |record, accumulator|
+  level = record.at_xpath("/ead/archdesc").attribute("level")&.value
+  other_level = record.at_xpath("/ead/archdesc").attribute("otherlevel")&.value
+
+  accumulator << Arclight::LevelLabel.new(level, other_level).to_s
+  accumulator << "Collection" unless level == "collection"
+end
+
+to_field "unitid_ssm", extract_xpath("/ead/archdesc/did/unitid")
+to_field "unitid_teim", extract_xpath("/ead/archdesc/did/unitid")
+to_field "collection_unitid_ssm", extract_xpath("/ead/archdesc/did/unitid")
+
+to_field "normalized_title_ssm" do |_record, accumulator, context|
+  dates = Plantain::NormalizedDate.new(
+    context.output_hash["unitdate_inclusive_ssm"],
+    context.output_hash["unitdate_bulk_ssim"],
+    context.output_hash["unitdate_other_ssim"]
+  ).to_s
+  title = context.output_hash["title_ssm"].first
+  accumulator << Plantain::NormalizedTitle.new(title, dates).to_s
+end
+
+to_field "normalized_date_ssm" do |_record, accumulator, context|
+  accumulator << Plantain::NormalizedDate.new(
+    context.output_hash["unitdate_inclusive_ssm"],
+    context.output_hash["unitdate_bulk_ssim"],
+    context.output_hash["unitdate_other_ssim"]
+  ).to_s
+end
+
+to_field "collection_ssm" do |_record, accumulator, context|
+  accumulator.concat context.output_hash.fetch("normalized_title_ssm", [])
+end
+to_field "collection_sim" do |_record, accumulator, context|
+  accumulator.concat context.output_hash.fetch("normalized_title_ssm", [])
+end
+to_field "collection_ssi" do |_record, accumulator, context|
+  accumulator.concat context.output_hash.fetch("normalized_title_ssm", [])
+end
+to_field "collection_title_tesim" do |_record, accumulator, context|
+  accumulator.concat context.output_hash.fetch("normalized_title_ssm", [])
+end
+
+to_field "repository_ssm" do |_record, accumulator, context|
+  accumulator << context.clipboard[:repository]
+end
+
+to_field "repository_sim" do |_record, accumulator, context|
+  accumulator << context.clipboard[:repository]
+end
+
+to_field "geogname_ssm", extract_xpath("/ead/archdesc/controlaccess/geogname")
+to_field "geogname_sim", extract_xpath("/ead/archdesc/controlaccess/geogname")
+
+to_field "creator_ssm", extract_xpath("/ead/archdesc/did/origination")
+to_field "creator_sim", extract_xpath("/ead/archdesc/did/origination")
+to_field "creator_ssim", extract_xpath("/ead/archdesc/did/origination")
+to_field "creator_sort" do |record, accumulator|
+  accumulator << record.xpath("/ead/archdesc/did/origination").map { |c| c.text.strip }.join(", ")
+end
+
+to_field "creator_persname_ssm", extract_xpath("/ead/archdesc/did/origination/persname")
+to_field "creator_persname_ssim", extract_xpath("/ead/archdesc/did/origination/persname")
+to_field "creator_corpname_ssm", extract_xpath("/ead/archdesc/did/origination/corpname")
+to_field "creator_corpname_sim", extract_xpath("/ead/archdesc/did/origination/corpname")
+to_field "creator_corpname_ssim", extract_xpath("/ead/archdesc/did/origination/corpname")
+to_field "creator_famname_ssm", extract_xpath("/ead/archdesc/did/origination/famname")
+to_field "creator_famname_ssim", extract_xpath("/ead/archdesc/did/origination/famname")
+
+to_field "persname_sim", extract_xpath("//persname")
+
+to_field "creators_ssim" do |_record, accumulator, context|
+  accumulator.concat context.output_hash["creator_persname_ssm"] if context.output_hash["creator_persname_ssm"]
+  accumulator.concat context.output_hash["creator_corpname_ssm"] if context.output_hash["creator_corpname_ssm"]
+  accumulator.concat context.output_hash["creator_famname_ssm"] if context.output_hash["creator_famname_ssm"]
+end
+
+to_field "places_sim", extract_xpath("/ead/archdesc/controlaccess/geogname")
+to_field "places_ssim", extract_xpath("/ead/archdesc/controlaccess/geogname")
+to_field "places_ssm", extract_xpath("/ead/archdesc/controlaccess/geogname")
+
+to_field "access_terms_ssm", extract_xpath('/ead/archdesc/userestrict/*[local-name()!="head"]')
+
+to_field "acqinfo_ssim", extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
+to_field "acqinfo_ssim", extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
+to_field "acqinfo_ssm" do |_record, accumulator, context|
+  accumulator.concat(context.output_hash.fetch("acqinfo_ssim", []))
+end
+
+to_field "access_subjects_ssim", extract_xpath("/ead/archdesc/controlaccess", to_text: false) do |_record, accumulator|
+  accumulator.map! do |element|
+    %w[subject function occupation genreform].map do |selector|
+      element.xpath(".//#{selector}").map(&:text)
+    end
+  end.flatten!
+end
+
+to_field "access_subjects_ssm" do |_record, accumulator, context|
+  accumulator.concat Array.wrap(context.output_hash["access_subjects_ssim"])
+end
+
+to_field "has_online_content_ssim", extract_xpath(".//dao") do |_record, accumulator|
+  accumulator.replace([accumulator.any?])
+end
+
+to_field "digital_objects_ssm", extract_xpath("/ead/archdesc/did/dao|/ead/archdesc/dao", to_text: false) do |_record, accumulator|
+  accumulator.map! do |dao|
+    label = dao.attributes["title"]&.value ||
+            dao.xpath("daodesc/p")&.text
+    href = (dao.attributes["href"] || dao.attributes["xlink:href"])&.value
+    Arclight::DigitalObject.new(label: label, href: href).to_json
+  end
+end
+
+to_field "extent_ssm", extract_xpath("/ead/archdesc/did/physdesc/extent")
+to_field "extent_teim", extract_xpath("/ead/archdesc/did/physdesc/extent")
+to_field "genreform_sim", extract_xpath("/ead/archdesc/controlaccess/genreform")
+to_field "genreform_ssm", extract_xpath("/ead/archdesc/controlaccess/genreform")
+
+to_field "date_range_sim", extract_xpath("/ead/archdesc/did/unitdate/@normal", to_text: false) do |_record, accumulator|
+  range = Plantain::YearRange.new
+  next range.years if accumulator.blank?
+
+  ranges = accumulator.map(&:to_s)
+  range << range.parse_ranges(ranges)
+  accumulator.replace range.years
+end
+
+SEARCHABLE_NOTES_FIELDS.map do |selector|
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
+  to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == "prefercite"
+  to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
+end
+
+DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
+end
+
+NAME_ELEMENTS.map do |selector|
+  to_field "names_coll_ssim", extract_xpath("/ead/archdesc/controlaccess/#{selector}")
+  to_field "names_ssim", extract_xpath("//#{selector}")
+  to_field "#{selector}_ssm", extract_xpath("//#{selector}")
+end
+
+to_field "corpname_sim", extract_xpath("//corpname")
+
+to_field "language_sim", extract_xpath("/ead/archdesc/did/langmaterial")
+to_field "language_ssm", extract_xpath("/ead/archdesc/did/langmaterial")
+
+to_field "descrules_ssm", extract_xpath("/ead/eadheader/profiledesc/descrules")
+
+# =============================
+# Each component child document
+# <c> <c01> <c12>
+# =============================
+
+# rubocop:disable Metrics/BlockLength
+compose "components", ->(record, accumulator, _context) { accumulator.concat record.xpath("//*[is_component(.)]", NokogiriXpathExtensions.new) } do
+  to_field "ref_ssi" do |record, accumulator, context|
+    accumulator << if record.attribute("id").blank?
+                     strategy = Arclight::MissingIdStrategy.selected
+                     hexdigest = strategy.new(record).to_hexdigest
+                     parent_id = context.clipboard[:parent].output_hash["id"].first
+                     logger.warn("MISSING ID WARNING") do
+                       [
+                         "A component in #{parent_id} did not have an ID so one was minted using the #{strategy} strategy.",
+                         "The ID of this document will be #{parent_id}#{hexdigest}."
+                       ].join(" ")
+                     end
+                     record["id"] = hexdigest
+                     hexdigest
+                   else
+                     record.attribute("id")&.value&.strip&.gsub(".", "-")
+                   end
+  end
+  to_field "ref_ssm" do |_record, accumulator, context|
+    accumulator.concat context.output_hash["ref_ssi"]
+  end
+
+  to_field "id" do |_record, accumulator, context|
+    accumulator << [
+      context.clipboard[:parent].output_hash["id"],
+      context.output_hash["ref_ssi"]
+    ].join("")
+  end
+
+  to_field "ead_ssi" do |_record, accumulator, context|
+    accumulator << context.clipboard[:parent].output_hash["ead_ssi"].first
+  end
+
+  to_field "title_filing_si", extract_xpath("./did/unittitle"), first_only
+  to_field "title_ssm", extract_xpath("./did/unittitle")
+  to_field "title_teim", extract_xpath("./did/unittitle")
+
+  to_field "unitdate_bulk_ssim", extract_xpath('./did/unitdate[@type="bulk"]')
+  to_field "unitdate_inclusive_ssm", extract_xpath('./did/unitdate[@type="inclusive"]')
+  to_field "unitdate_other_ssim", extract_xpath("./did/unitdate[not(@type)]")
+
+  to_field "normalized_title_ssm" do |_record, accumulator, context|
+    dates = Plantain::NormalizedDate.new(
+      context.output_hash["unitdate_inclusive_ssm"],
+      context.output_hash["unitdate_bulk_ssim"],
+      context.output_hash["unitdate_other_ssim"]
+    ).to_s
+    title = context.output_hash["title_ssm"]&.first
+    accumulator << Plantain::NormalizedTitle.new(title, dates).to_s
+  end
+
+  to_field "normalized_date_ssm" do |_record, accumulator, context|
+    accumulator << Plantain::NormalizedDate.new(
+      context.output_hash["unitdate_inclusive_ssm"],
+      context.output_hash["unitdate_bulk_ssim"],
+      context.output_hash["unitdate_other_ssim"]
+    ).to_s
+  end
+
+  to_field "component_level_isim" do |record, accumulator|
+    accumulator << 1 + NokogiriXpathExtensions.new.is_component(record.ancestors).count
+  end
+
+  to_field "parent_ssm" do |record, accumulator, context|
+    accumulator << context.clipboard[:parent].output_hash["id"].first
+    accumulator.concat NokogiriXpathExtensions.new.is_component(record.ancestors).reverse.map { |n| n.attribute("id")&.value }
+  end
+
+  to_field "parent_ssi" do |_record, accumulator, context|
+    accumulator << context.output_hash["parent_ssm"].last
+  end
+
+  to_field "parent_unittitles_ssm" do |_rec, accumulator, context|
+    # top level document
+    accumulator.concat context.clipboard[:parent].output_hash["normalized_title_ssm"]
+    parent_ssm = context.output_hash["parent_ssm"]
+    components = context.clipboard[:parent].output_hash["components"]
+
+    # other components
+    if parent_ssm && components
+      ancestors = parent_ssm.drop(1).map { |x| [x] }
+      accumulator.concat components.select { |c| ancestors.include? c["ref_ssi"] }.flat_map { |c| c["normalized_title_ssm"] }
+    end
+  end
+
+  to_field "parent_unittitles_teim" do |_record, accumulator, context|
+    accumulator.concat context.output_hash["parent_unittitles_ssm"]
+  end
+
+  to_field "parent_levels_ssm" do |_record, accumulator, context|
+    ## Top level document
+    accumulator.concat context.clipboard[:parent].output_hash["level_ssm"]
+    ## Other components
+    context.output_hash["parent_ssm"]&.drop(1)&.each do |id|
+      accumulator.concat Array
+        .wrap(context.clipboard[:parent].output_hash["components"])
+        .select { |c| c["ref_ssi"] == [id] }.map { |c| c["level_ssm"] }.flatten
+    end
+  end
+
+  to_field "unitid_ssm", extract_xpath("./did/unitid")
+  to_field "collection_unitid_ssm" do |_record, accumulator, context|
+    accumulator.concat Array.wrap(context.clipboard[:parent].output_hash["unitid_ssm"])
+  end
+  to_field "repository_ssm" do |_record, accumulator, context|
+    accumulator << context.clipboard[:parent].clipboard[:repository]
+  end
+  to_field "repository_sim" do |_record, accumulator, context|
+    accumulator << context.clipboard[:parent].clipboard[:repository]
+  end
+  to_field "collection_ssm" do |_record, accumulator, context|
+    accumulator.concat context.clipboard[:parent].output_hash["normalized_title_ssm"]
+  end
+  to_field "collection_sim" do |_record, accumulator, context|
+    accumulator.concat context.clipboard[:parent].output_hash["normalized_title_ssm"]
+  end
+  to_field "collection_ssi" do |_record, accumulator, context|
+    accumulator.concat context.clipboard[:parent].output_hash["normalized_title_ssm"]
+  end
+
+  to_field "extent_ssm", extract_xpath("./did/physdesc/extent")
+  to_field "extent_teim", extract_xpath("./did/physdesc/extent")
+
+  to_field "creator_ssm", extract_xpath("./did/origination")
+  to_field "creator_ssim", extract_xpath("./did/origination")
+  to_field "creators_ssim", extract_xpath("./did/origination")
+  to_field "creator_sort" do |record, accumulator|
+    accumulator << record.xpath("./did/origination").map(&:text).join(", ")
+  end
+  to_field "collection_creator_ssm" do |_record, accumulator, context|
+    accumulator.concat Array.wrap(context.clipboard[:parent].output_hash["creator_ssm"])
+  end
+  to_field "has_online_content_ssim", extract_xpath(".//dao") do |_record, accumulator|
+    accumulator.replace([accumulator.any?])
+  end
+  to_field "child_component_count_isim" do |record, accumulator|
+    accumulator << NokogiriXpathExtensions.new.is_component(record.children).count
+  end
+
+  to_field "ref_ssm" do |record, accumulator|
+    accumulator << record.attribute("id")
+  end
+
+  to_field "level_ssm" do |record, accumulator|
+    level = record.attribute("level")&.value
+    other_level = record.attribute("otherlevel")&.value
+    accumulator << Arclight::LevelLabel.new(level, other_level).to_s
+  end
+
+  to_field "level_sim" do |_record, accumulator, context|
+    next unless context.output_hash["level_ssm"]
+
+    accumulator.concat context.output_hash["level_ssm"]&.map(&:capitalize)
+  end
+
+  to_field "sort_ii" do |_record, accumulator, context|
+    accumulator.replace([context.position])
+  end
+
+  # Get the <accessrestrict> from the closest ancestor that has one (includes top-level)
+  to_field "parent_access_restrict_ssm" do |record, accumulator|
+    accumulator.concat Array
+      .wrap(record.xpath('(./ancestor::*/accessrestrict)[last()]/*[local-name()!="head"]')
+      .map(&:text))
+  end
+
+  # Get the <userestrict> from self OR the closest ancestor that has one (includes top-level)
+  to_field "parent_access_terms_ssm" do |record, accumulator|
+    accumulator.concat Array
+      .wrap(record.xpath('(./ancestor-or-self::*/userestrict)[last()]/*[local-name()!="head"]')
+      .map(&:text))
+  end
+
+  to_field "digital_objects_ssm", extract_xpath(".//dao", to_text: false) do |_record, accumulator|
+    accumulator.map! do |dao|
+      label = dao.attributes["title"]&.value ||
+              dao.xpath("daodesc/p")&.text
+      href = (dao.attributes["href"] || dao.attributes["xlink:href"])&.value
+      Arclight::DigitalObject.new(label: label, href: href).to_json
+    end
+  end
+
+  to_field "direct_digital_objects_ssm", extract_xpath("./dao", to_text: false) do |_record, accumulator|
+    accumulator.map! do |dao|
+      label = dao.attributes["title"]&.value ||
+              dao.xpath("daodesc/p")&.text
+      href = (dao.attributes["href"] || dao.attributes["xlink:href"])&.value
+      Arclight::DigitalObject.new(label: label, href: href).to_json
+    end
+  end
+
+  to_field "date_range_sim", extract_xpath("./did/unitdate/@normal", to_text: false) do |_record, accumulator|
+    range = Plantain::YearRange.new
+    next range.years if accumulator.blank?
+
+    ranges = accumulator.map(&:to_s)
+    range << range.parse_ranges(ranges)
+    accumulator.replace range.years
+  end
+
+  NAME_ELEMENTS.map do |selector|
+    to_field "names_ssim", extract_xpath("./controlaccess/#{selector}")
+    to_field "#{selector}_ssm", extract_xpath(".//#{selector}")
+  end
+
+  to_field "geogname_sim", extract_xpath("./controlaccess/geogname")
+  to_field "geogname_ssm", extract_xpath("./controlaccess/geogname")
+  to_field "places_ssim", extract_xpath("./controlaccess/geogname")
+
+  to_field "access_subjects_ssim", extract_xpath("./controlaccess", to_text: false) do |_record, accumulator|
+    accumulator.map! do |element|
+      %w[subject function occupation genreform].map do |selector|
+        element.xpath(".//#{selector}").map(&:text)
+      end
+    end.flatten!
+  end
+
+  to_field "access_subjects_ssm" do |_record, accumulator, context|
+    accumulator.concat(context.output_hash.fetch("access_subjects_ssim", []))
+  end
+
+  to_field "acqinfo_ssim", extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
+  to_field "acqinfo_ssim", extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
+  to_field "acqinfo_ssim", extract_xpath('./acqinfo/*[local-name()!="head"]')
+  to_field "acqinfo_ssim", extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
+  to_field "acqinfo_ssm" do |_record, accumulator, context|
+    accumulator.concat(context.output_hash.fetch("acqinfo_ssim", []))
+  end
+
+  to_field "language_ssm", extract_xpath("./did/langmaterial")
+  to_field "containers_ssim" do |record, accumulator|
+    record.xpath("./did/container").each do |node|
+      accumulator << [node.attribute("type"), node.text].join(" ").strip
+    end
+  end
+
+  SEARCHABLE_NOTES_FIELDS.map do |selector|
+    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
+    to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
+    to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
+  end
+  DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
+    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
+  end
+  to_field "did_note_ssm", extract_xpath("./did/note")
+end
+# rubocop:enable Metrics/BlockLength
+
+each_record do |_record, context|
+  context.output_hash["components"] &&= context.output_hash["components"].select { |c| c.keys.any? }
+end
+
+##
+# Used for evaluating xpath components to find
+class NokogiriXpathExtensions
+  # rubocop:disable Naming/PredicateName, Style/FormatString
+  def is_component(node_set)
+    node_set.find_all do |node|
+      component_elements = (1..12).map { |i| "c#{'%02d' % i}" }
+      component_elements.push "c"
+      component_elements.include? node.name
+    end
+  end
+  # rubocop:enable Naming/PredicateName, Style/FormatString
+end

--- a/lib/plantain/year_range.rb
+++ b/lib/plantain/year_range.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Plantain
+  # Class for modeling ranges in years parsed from encoded dates in EAD Documents
+  class YearRange < Arclight::YearRange
+    # Parses an array of dates from a string extracted from an EAD Document
+    # @param dates [String]
+    # @return [Array<Integer>]
+    def parse_range(dates)
+      return if dates.blank?
+      year_u, year_v = dates.split("/").map { |date| to_year_from_iso8601(date) }
+      return [year_u] if year_v.blank?
+      return (year_v..year_u).to_a unless year_u <= year_v
+      (year_u..year_v).to_a
+    end
+  end
+end

--- a/lib/tasks/plantain.rake
+++ b/lib/tasks/plantain.rake
@@ -109,7 +109,7 @@ namespace :plantain do
   # Retrieve the file path for the ArcLight core Traject configuration
   # @return [String]
   def arclight_config_path
-    pathname = Arclight::Engine.root.join("lib", "arclight", "traject", "ead2_config.rb")
+    pathname = Rails.root.join("lib", "plantain", "traject", "ead2_config.rb")
     pathname.to_s
   end
 

--- a/lib/tasks/pulfa.rake
+++ b/lib/tasks/pulfa.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+namespace :pulfa do
+  desc "Retrieve the PULFA finding aid EAD Documents Subversion"
+  task :checkout do
+    check_if_lpass_installed
+    check_if_logged_in
+
+    lastpass_pulfa_svn_username = "Shared-ITIMS-Passwords/pulfa_svn_username"
+    lastpass_pulfa_svn_password = "Shared-ITIMS-Passwords/pulfa_svn_password"
+    lastpass_pulfa_svn_url = "Shared-ITIMS-Passwords/pulfa_svn_url"
+
+    username = `lpass show --notes #{lastpass_pulfa_svn_username}`
+    username.chomp!
+    password = `lpass show --notes #{lastpass_pulfa_svn_password}`
+    password.chomp!
+    svn_url = `lpass show --notes #{lastpass_pulfa_svn_url}`
+    svn_url.chomp!
+
+    cmd = "/usr/bin/env svn checkout #{svn_url} eads/pulfa/ --username #{username} --non-interactive --password #{password}"
+
+    exit_code = system(cmd)
+    exit(exit_code)
+  end
+
+  # Utility methods
+
+  # Determine if the lpass binary is installed and in the $PATH
+  # @return [Boolean]
+  def check_if_lpass_installed
+    abort("You don't have the 'lpass' command tool") if `which lpass`.empty?
+  end
+
+  # Determine if the system user has authenticated using lpass
+  # @return [Boolean]
+  def check_if_logged_in
+    abort("You must login first with: lpass login <login@name.com>") if system("lpass status -q") == false
+  end
+end


### PR DESCRIPTION
Resolves #40 by addressing the following:
- Providing steps within the README for retrieving the PULFA EAD Documents
- Implementing the `NormalizedDate`, `NormalizedTitle`, and `YearRange` Classes for overriding the default EAD parsing

This also includes an overridden the EAD 2002 configuration for the Traject parser in order to inject the overridden classes.