### PR TITLE
Require pry for tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 ENV["RACK_ENV"] = "test"
 require "coveralls"
 require "simplecov"
+require "pry"
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [


### PR DESCRIPTION
Not sure why bundler isn't doing this for us, but it's annoying to have
to do it every time you want to add a breakpoint.t